### PR TITLE
Config Cleanup and enhancements

### DIFF
--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -171,12 +171,6 @@ gcode:
   QUAD_GANTRY_LEVEL_BASE
   G28 Z
 
-[gcode_macro M84]
-rename_existing: M84_BASE
-gcode:
-  _LM_DISABLE
-  M84_BASE
-
 #####################################################################
 #   Gcode Shell Commands
 #####################################################################

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -131,10 +131,11 @@ gcode:
 gcode:  
     {% if printer[printer.toolhead.extruder].temperature > printer.configfile.settings['extruder'].min_extrude_temp %}
       {% set speed = params.SPEED|default(300) %}  
-      {% set max_velocity = printer.configfile.settings['extruder'].max_extrude_only_velocity %}  
+      {% set max_velocity = printer.configfile.settings['extruder'].max_extrude_only_velocity %}
+      M118 Loading filament  
       G91  
       G92 E0   
-      G1 E25 F{speed} # purge
+      G1 E55 F{speed} # purge
     {% else %}
       M118 Error: Extruder temperature too low, unable to load filament.
     {% endif %}
@@ -144,9 +145,10 @@ gcode:
 gcode:  
     {% if printer[printer.toolhead.extruder].temperature > printer.configfile.settings['extruder'].min_extrude_temp %}
       {% set speed = params.SPEED|default(300) %}  
-      {% set max_velocity = printer.configfile.settings['extruder'].max_extrude_only_velocity %}  
+      {% set max_velocity = printer.configfile.settings['extruder'].max_extrude_only_velocity %}
+      M118 Unloading filament  
       G92 E0   
-      G1 E-25 F{max_velocity} # fast-unload  
+      G1 E-105 F{max_velocity} # fast-unload  
     {% else %}
       M118 Error: Extruder temperature too low, unable to unload filament.
     {% endif %}

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -1,62 +1,104 @@
-[gcode_macro BED_MESH_CALIBRATE]
-rename_existing:BED_MESH_CALIBRATE_BASE
+
+#####################################################################
+#   Print Start/End
+#####################################################################
+
+[gcode_macro PRINT_START]
+gcode:
+  _LM_ENABLE
+  _MESH_LOAD
+  LEVEL_BED
+  G90
+  # Create a purge line and starts the print
+  G0 Y3 X150 F6000.0     ; go to tongue of print bed
+  G1 Z0.2 F500.0         ; move bed to nozzle
+  G92 E0.0               ; reset extruder
+  G1 E2 F500.0           ; pre-purge prime LENGTH SHOULD MATCH YOUR PRINT_END RETRACT
+  G1 X250 E20.0 F1500.0  ; intro line 1
+  G1 Y3.3 F500           ; move in a little
+  G1 X150 E20.0 F1500.0   ; second line
+  G92 E0.0               ; reset extruder
+  G1 Z2.0                ; move nozzle to prevent scratch
+
+[gcode_macro PRINT_END]
+gcode:
+  G91 
+  G1 Z+30
+  G1 E-5 F300
+  G90
+  # Moves toolhead to rear corner for ease of print removal
+  G1 X10 Y290 F12000
+  M104 S0 
+  M140 S0
+  M106 S0
+  _LM_DISABLE
+
+#####################################################################
+#   Calibration
+#####################################################################
+
+[gcode_macro LEVEL_BED]
+description: Auto level bed
+gcode:
+  QUAD_GANTRY_LEVEL
+
+[gcode_macro CREATE_BED_MESH]
+description: Create or update the "default" bed mesh
+gcode:
+  BED_MESH_CALIBRATE
+
+[gcode_macro FULL_CALIBRATE_BED]
+description: Level bed and create or update the "default" mesh
+gcode:
+  QUAD_GANTRY_LEVEL
+  BED_MESH_CALIBRATE
+
+#####################################################################
+#   Misc. Util.
+#####################################################################
+
+# This convinces Klipper the toolhead is at 0,0 and the bed is halfway down. 
+# Don't break things with this.
+[gcode_macro SET_XYZ_POSITION]
+description: Tells printer toolhead is at 0,0 and bed is at 150mm. 
+gcode:
+  SET_KINEMATIC_POSITION X=0 Y=0 Z=150
+
+[gcode_macro RUN_INPUT_SHAPER]
+description: Currently not reccomended due to driver smoothing in effect.
+gcode:
+  SHAPER_CALIBRATE
+
+# This will crash into prints if you leave them on the bed after print completion.
+[gcode_macro Z_TO_BOTTOM]
+description: Homes if not already, then moves Z to bottom.
 gcode:
   {% if "z" not in printer.toolhead.homed_axes %}
     G28 Z
   {% endif %}
-  M118 Heating the bed, please wait...
-  M190 S50
-  M118 Complete heating and start executing bed mesh calibrate
-  BED_MESH_CALIBRATE_BASE
-  G28 Z
-
-[gcode_macro QUAD_GANTRY_LEVEL]
-rename_existing: QUAD_GANTRY_LEVEL_BASE
-gcode:
-  G28
-  M118 Heating the bed, please wait...
-  M190 S50
-  M118 Complete heating and start executing quad gantry level
-  QUAD_GANTRY_LEVEL_BASE
-  G28 Z
-
-[gcode_macro CALIBRATE_BED]
-description: Level bed and create or update the "default" mesh
-gcode:
-  LM_ENABLE
-  M190 S50
-  M109 S150
-  QUAD_GANTRY_LEVEL_BASE
-  BED_MESH_CALIBRATE_BASE
-
-
-[gcode_macro TUNE_BED_PID]
-gcode:
-  PID_CALIBRATE HEATER=heater_bed TARGET=60
-
-[gcode_macro TUNE_EXTRUDER_PID]
-gcode:
-  PID_CALIBRATE HEATER=extruder TARGET=190
-
-[gcode_macro SET_XYZ_POSITION]
-gcode:
-  SET_KINEMATIC_POSITION X=100 Y=100 Z=100
-
-[gcode_macro RUN_INPUT_SHAPER]
-gcode:
-  SHAPER_CALIBRATE
-
-[gcode_macro PRINT_START]
-gcode:
-  LM_ENABLE
-  MESH_LOAD
-  G28
-  G90
-
-[gcode_macro Z_TO_BOTTOM]
-gcode:
-  G28
   G1 Z295
+
+#####################################################################
+#   Pause/Resume
+#####################################################################
+
+[gcode_macro PAUSE]
+rename_existing: BASE_PAUSE
+gcode:
+  {% if printer.pause_resume.is_paused %}
+    { action_respond_info("Print already paused") }
+  {% elif printer.idle_timeout.state | string == "Printing" and printer.pause_resume.is_paused == False %}
+      SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE={printer[printer.toolhead.extruder].target} 
+      SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_fan_speed VALUE={printer["fan"].speed}   
+      SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_jetstream_speed VALUE={printer["fan_generic Jetstream"].speed}   
+      SAVE_GCODE_STATE NAME=PAUSE                                                          
+      BASE_PAUSE                                                                           
+      G1 Z{printer.gcode_move.position.z+10} F300
+      G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_minimum.y+5} F6000  
+      SAVE_GCODE_STATE NAME=PAUSEPARK      
+      M107
+      UPDATE_DELAYED_GCODE ID=cool_hot_end DURATION=300   
+    {% endif %}
 
 [gcode_macro RESUME]
 rename_existing: BASE_RESUME
@@ -75,45 +117,15 @@ gcode:
     _CLIENT_EXTRUDE
     BASE_RESUME VELOCITY={params.VELOCITY|default(sp_move)}
 
-
 [delayed_gcode cool_hot_end]
 gcode:
     {% if printer['pause_resume'].is_paused|int == 1 %}
       M104 S0   
     {% endif %}
 
-[gcode_macro PAUSE]
-rename_existing: BASE_PAUSE
-gcode:
-    {% if printer['pause_resume'].is_paused|int == 0 %}
-        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE={printer[printer.toolhead.extruder].target} 
-        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_fan_speed VALUE={printer["fan"].speed}   
-        SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_jetstream_speed VALUE={printer["fan_generic Jetstream"].speed}   
-        SAVE_GCODE_STATE NAME=PAUSE                                                          
-        BASE_PAUSE                                                                           
-        G1 Z{printer.gcode_move.position.z+10} F300
-        G1 X{printer.toolhead.axis_maximum.x/2} Y{printer.toolhead.axis_minimum.y+5} F6000  
-        SAVE_GCODE_STATE NAME=PAUSEPARK      
-        M107
-        UPDATE_DELAYED_GCODE ID=cool_hot_end DURATION=240   
-    {% endif %}
-
-
-[gcode_macro MESH_LOAD]
-gcode:
-    BED_MESH_PROFILE LOAD=default
-
-[gcode_macro PRINT_END]
-gcode:
-  G91 
-  G1 Z5
-  G1 E-5 F300
-  G90
-  G1 X200 Y10  F12000
-  M104 S0 
-  M140 S0
-  M106 S0
-  LM_DISABLE
+#####################################################################
+#   Filament
+#####################################################################
 
 [gcode_macro LOAD_FILAMENT] 
 gcode:  
@@ -124,7 +136,7 @@ gcode:
       G92 E0   
       G1 E25 F{speed} # purge
     {% else %}
-      M118 Extruder temperature too low,please heat the nozzle first
+      M118 Extruder temperature too low, please heat the nozzle first
     {% endif %}
 
 
@@ -138,6 +150,87 @@ gcode:
     {% else %}
       M118 Extruder temperature too low, please heat the nozzle first
     {% endif %}
+
+#####################################################################
+#   Renamed
+#####################################################################
+
+[gcode_macro BED_MESH_CALIBRATE]
+rename_existing:BED_MESH_CALIBRATE_BASE
+gcode:
+  {% if "z" not in printer.toolhead.homed_axes %}
+    G28 Z
+  {% endif %}
+  BED_MESH_CALIBRATE_BASE
+  G28 Z
+
+  [gcode_macro QUAD_GANTRY_LEVEL]
+rename_existing: QUAD_GANTRY_LEVEL_BASE
+gcode:
+  G28
+  QUAD_GANTRY_LEVEL_BASE
+  G28 Z
+
+#####################################################################
+#   Gcode Shell Commands
+#####################################################################
+
+[gcode_shell_command  RESIZE_FILE_SYSTEM]
+command: curl -G http://127.0.0.1:8880/auto_resize_filesystem
+timeout: 2.
+verbose: False
+
+[gcode_shell_command LINEAR_MOTOR_ENABLE]
+command: curl -G http://127.0.0.1:8880/send_command?command=ENABLE
+timeout: 2.
+verbose: False
+
+
+[gcode_shell_command LINEAR_MOTOR_DISABLE]
+command: curl -G http://127.0.0.1:8880/send_command?command=DISABLE
+timeout: 2.
+verbose: False
+
+#####################################################################
+#   Hidden
+#####################################################################
+
+[gcode_macro _RESIZE_FILESYSTEM]
+gcode:
+  RUN_SHELL_COMMAND CMD=RESIZE_FILE_SYSTEM
+
+[gcode_macro _RUNOUT_PAUSE]
+gcode:
+  M118 Filament runout triggered, pausing
+  PAUSE
+
+[gcode_macro _MESH_LOAD]
+gcode:
+    BED_MESH_PROFILE LOAD=default
+
+[gcode_macro _LINEAR_MOTOR]
+gcode:
+  {% if params.ENABLE is defined %}
+    {% if params.ENABLE|int == 0 %}
+      RUN_SHELL_COMMAND CMD=LINEAR_MOTOR_DISABLE
+    {% else %}
+      RUN_SHELL_COMMAND CMD=LINEAR_MOTOR_ENABLE
+    {% endif %}
+  {% else %}
+    RUN_SHELL_COMMAND CMD=LINEAR_MOTOR_ENABLE
+  {% endif %}
+
+[gcode_macro _LM_ENABLE]
+gcode:
+  RUN_SHELL_COMMAND CMD=LINEAR_MOTOR_ENABLE
+  
+[gcode_macro _LM_DISABLE]
+gcode:
+  RUN_SHELL_COMMAND CMD=LINEAR_MOTOR_DISABLE
+
+#####################################################################
+#   Fan Shenanagins
+#####################################################################
 
 [gcode_macro M106]
 rename_existing: G106
@@ -179,57 +272,3 @@ gcode:
       SET_FAN_SPEED FAN=Jetstream SPEED=0  
       G107
     {% endif %}
-
-[gcode_shell_command  RESIZE_FILE_SYSTEM]
-command: curl -G http://127.0.0.1:8880/auto_resize_filesystem
-timeout: 2.
-verbose: False
-
-[gcode_macro RESIZE_FILESYSTEM]
-gcode:
-  RUN_SHELL_COMMAND CMD=RESIZE_FILE_SYSTEM
-
-[gcode_shell_command  LINER_MOTOR_ENABLE]
-command: curl -G http://127.0.0.1:8880/send_command?command=ENABLE
-timeout: 2.
-verbose: False
-
-
-[gcode_shell_command  LINER_MOTOR_DISABLE]
-command: curl -G http://127.0.0.1:8880/send_command?command=DISABLE
-timeout: 2.
-verbose: False
-
-
-[gcode_macro LINER_MOTOR]
-gcode:
-  {% if params.ENABLE is defined %}
-    {% if params.ENABLE|int == 0 %}
-      RUN_SHELL_COMMAND CMD=LINER_MOTOR_DISABLE
-    {% else %}
-      RUN_SHELL_COMMAND CMD=LINER_MOTOR_ENABLE
-    {% endif %}
-  {% else %}
-    RUN_SHELL_COMMAND CMD=LINER_MOTOR_DISABLE
-  {% endif %}
-
-[gcode_macro LM_ENABLE]
-gcode:
-  G4 P500
-  RUN_SHELL_COMMAND CMD=LINER_MOTOR_ENABLE
-  
-[gcode_macro LM_DISABLE]
-gcode:
-  RUN_SHELL_COMMAND CMD=LINER_MOTOR_ENABLE
-
-# [gcode_macro M300]
-# description: Enables M300 commands
-# gcode:
-#   #use a default 1kHz tone if S is omitted
-#   {% set S = params.S|default(1000)|int %}
-#   #use a 10ms duration if P is omitted
-#   {% set P = params.P|default(10)|int %}
-#   SET_PIN PIN=beeper_pin VALUE=0.5 CYCLE_TIME={1.0/S if S > 0 else 1}
-#   G4 P{P}
-#   SET_PIN PIN=beeper_pin VALUE=0
-  

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -65,7 +65,7 @@ gcode:
   SET_KINEMATIC_POSITION X=0 Y=0 Z=150
 
 [gcode_macro RUN_INPUT_SHAPER]
-description: Currently not reccomended due to driver smoothing in effect.
+description: Currently not recommended due to driver smoothing in effect.
 gcode:
   SHAPER_CALIBRATE
 

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -156,7 +156,7 @@ gcode:
 #####################################################################
 
 [gcode_macro BED_MESH_CALIBRATE]
-rename_existing:BED_MESH_CALIBRATE_BASE
+rename_existing: BED_MESH_CALIBRATE_BASE
 gcode:
   {% if "z" not in printer.toolhead.homed_axes %}
     G28 Z
@@ -164,12 +164,18 @@ gcode:
   BED_MESH_CALIBRATE_BASE
   G28 Z
 
-  [gcode_macro QUAD_GANTRY_LEVEL]
+[gcode_macro QUAD_GANTRY_LEVEL]
 rename_existing: QUAD_GANTRY_LEVEL_BASE
 gcode:
   G28
   QUAD_GANTRY_LEVEL_BASE
   G28 Z
+
+[gcode_macro M84]
+rename_existing: M84_BASE
+gcode:
+  _LM_DISABLE
+  M84_BASE
 
 #####################################################################
 #   Gcode Shell Commands

--- a/config/macros.cfg
+++ b/config/macros.cfg
@@ -136,7 +136,7 @@ gcode:
       G92 E0   
       G1 E25 F{speed} # purge
     {% else %}
-      M118 Extruder temperature too low, please heat the nozzle first
+      M118 Error: Extruder temperature too low, unable to load filament.
     {% endif %}
 
 
@@ -146,9 +146,9 @@ gcode:
       {% set speed = params.SPEED|default(300) %}  
       {% set max_velocity = printer.configfile.settings['extruder'].max_extrude_only_velocity %}  
       G92 E0   
-      G1 E-20 F{max_velocity} # fast-unload  
+      G1 E-25 F{max_velocity} # fast-unload  
     {% else %}
-      M118 Extruder temperature too low, please heat the nozzle first
+      M118 Error: Extruder temperature too low, unable to unload filament.
     {% endif %}
 
 #####################################################################

--- a/config/magneto_toolhead.cfg
+++ b/config/magneto_toolhead.cfg
@@ -1,33 +1,11 @@
 [include magneto_device.cfg]
-#####################################################################
-#              fan
-#####################################################################
 
-## FAN0  
-[heater_fan hotend_fan]
-pin:MAG_TOOL:gpio1
-max_power: 1.0
-kick_start_time: 0.5
-heater: extruder
-heater_temp: 50.0
-fan_speed: 1.0
+#####################################################################
+#   General Toolhead
+#####################################################################
 
 [magneto_load_cell]
 pin: MAG_TOOL:gpio24
-
-[gcode_button UNL_FILA]
-pin: ^!MAG_TOOL:gpio27
-press_gcode:
-    #{% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
-    UNLOAD_FILAMENT
-    #{% endif %}
-
-[gcode_button L_FILA]
-pin: ^!MAG_TOOL:gpio20
-press_gcode:
-#    {% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
-    LOAD_FILAMENT
-#    {% endif %}
 
 [output_pin _load_cell_reset_pin]
 pin:MAG_TOOL:gpio25
@@ -36,12 +14,24 @@ value:1
 
 [gcode_macro CLEAR_LOAD_CELL]
 gcode:
-    LC28
+  LC28 
 
+#####################################################################
+#   Fan
+##################################################################### 
+
+[heater_fan hotend_fan]
+pin:MAG_TOOL:gpio1
+max_power: 1.0
+kick_start_time: 0.5
+heater: extruder
+heater_temp: 50.0
+fan_speed: 1.0
 
 #####################################################################
 #   Extruder
 #####################################################################
+
 # [adc_temperature extruder]
 # temperature1:27
 # voltage1:3.156
@@ -59,12 +49,6 @@ gcode:
 # voltage7:0.222
 # temperature8:300
 # voltage8:0.098
-
-# [verify_heater extruder]
-# max_error: 120
-# check_gain_time:50
-# hysteresis: 50
-# heating_gain: 4
 
 [extruder]
 step_pin: MAG_TOOL:gpio5
@@ -89,8 +73,6 @@ pid_kd=113.630
 pressure_advance: 0.0
 pressure_advance_smooth_time: 0.040
 
-
-
 [tmc2209 extruder]
 uart_pin: MAG_TOOL:gpio6
 interpolate: false
@@ -100,7 +82,7 @@ sense_resistor: 0.110
 stealthchop_threshold: 100
 
 #####################################################################
-#	  Neopixel
+#   Neopixel
 #####################################################################
 
 #[neopixel my_neopixel]
@@ -112,8 +94,13 @@ stealthchop_threshold: 100
 #initial_BLUE: 0.0
 
 #####################################################################
-#	ADXL345
+#   ADXL345
 #####################################################################
+
+[resonance_tester]
+accel_chip: adxl345
+accel_per_hz: 100  # default is 75
+probe_points: 200,150,20
 
 [adxl345]
 cs_pin: MAG_TOOL:gpio13
@@ -121,17 +108,25 @@ spi_software_sclk_pin: MAG_TOOL:gpio14
 spi_software_mosi_pin: MAG_TOOL:gpio15
 spi_software_miso_pin: MAG_TOOL:gpio12
 
-[resonance_tester]
-accel_chip: adxl345
-accel_per_hz: 100  # default is 75
-probe_points: 200,150,20
+#####################################################################
+#   Runout Sensor
+#####################################################################
 
 [filament_switch_sensor Runout_Sensor]
-pause_on_runout: True
-runout_gcode: PAUSE
+pause_on_runout: False
+runout_gcode: _RUNOUT_PAUSE
 switch_pin: ^MAG_TOOL:gpio29
 
+[gcode_button UNL_FILA]
+pin: ^!MAG_TOOL:gpio27
+press_gcode:
+    {% if printer.idle_timeout.state | string == "Idle" or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
+    UNLOAD_FILAMENT
+    {% endif %}
 
-
-
-
+[gcode_button L_FILA]
+pin: ^!MAG_TOOL:gpio20
+press_gcode:
+   {% if printer.idle_timeout.state | string == "Idle" or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
+    LOAD_FILAMENT
+   {% endif %}

--- a/config/magneto_toolhead.cfg
+++ b/config/magneto_toolhead.cfg
@@ -120,13 +120,15 @@ switch_pin: ^MAG_TOOL:gpio29
 [gcode_button UNL_FILA]
 pin: ^!MAG_TOOL:gpio27
 press_gcode:
-    {% if printer.idle_timeout.state | string == "Idle" or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
-    UNLOAD_FILAMENT
-    {% endif %}
+  {% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
+  M118 Unloading filament
+  UNLOAD_FILAMENT
+  {% endif %}
 
 [gcode_button L_FILA]
 pin: ^!MAG_TOOL:gpio20
 press_gcode:
-   {% if printer.idle_timeout.state | string == "Idle" or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
-    LOAD_FILAMENT
-   {% endif %}
+  {% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
+  M118 Loading filament
+  LOAD_FILAMENT
+  {% endif %}

--- a/config/magneto_toolhead.cfg
+++ b/config/magneto_toolhead.cfg
@@ -118,10 +118,9 @@ runout_gcode: _RUNOUT_PAUSE
 switch_pin: ^MAG_TOOL:gpio29
 
 [gcode_button UNL_FILA]
-pin: ^!MAG_TOOL:gpio27
+pin: ~MAG_TOOL:gpio27
 press_gcode:
   {% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
-  M118 Unloading filament
   UNLOAD_FILAMENT
   {% endif %}
 
@@ -129,6 +128,5 @@ press_gcode:
 pin: ^!MAG_TOOL:gpio20
 press_gcode:
   {% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
-  M118 Loading filament
   LOAD_FILAMENT
   {% endif %}

--- a/config/magneto_toolhead.cfg
+++ b/config/magneto_toolhead.cfg
@@ -118,7 +118,7 @@ runout_gcode: _RUNOUT_PAUSE
 switch_pin: ^MAG_TOOL:gpio29
 
 [gcode_button UNL_FILA]
-pin: ~MAG_TOOL:gpio27
+pin: ^MAG_TOOL:gpio27
 press_gcode:
   {% if printer.idle_timeout.state != 'Printing' or printer.pause_resume.is_paused %}  ; unload if not printing OR printing but paused
   UNLOAD_FILAMENT

--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -43,7 +43,7 @@ resolution:0.1
 [force_move]
 enable_force_move: True
 
-# Currently reccomended to not change this.
+# Currently recommended to not change this.
 # The linear motors have built in smoothing as well
 [input_shaper]
 shaper_type_y = zv

--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -2,9 +2,37 @@
 [include mainsail.cfg]
 [include macros.cfg]
 [include magneto_toolhead.cfg]
-[include magneto_device.cfg]
 
+#####################################################################
+#   Printer General
+#####################################################################
 
+[printer]
+kinematics: cartesian
+max_velocity: 1500
+max_accel: 15000
+max_z_velocity: 5
+max_z_accel: 100
+
+[board_pins]
+aliases:
+    # EXP1 header
+    EXP1_1=PE8, EXP1_2=PE7,
+    EXP1_3=PE9, EXP1_4=PE10,
+    EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
+    EXP1_7=PE14, EXP1_8=PE15,
+    EXP1_9=<GND>, EXP1_10=<5V>,
+
+    # EXP2 header
+    EXP2_1=PA6, EXP2_2=PA5,
+    EXP2_3=PB1, EXP2_4=PA4,
+    EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
+    EXP2_7=PC15, EXP2_8=<RST>,
+    EXP2_9=<GND>, EXP2_10=PC5
+
+[exclude_object]
+
+[respond]
 
 [idle_timeout]
 timeout: 3600
@@ -12,218 +40,17 @@ timeout: 3600
 [gcode_arcs]
 resolution:0.1
 
-#####################################################################
-#	Probe
-#####################################################################
-
-[probe]
-pin: PE12
-x_offset: 0
-y_offset: 0
-z_offset: -0.15 #default value
-speed: 2
-lift_speed: 7
-samples: 3
-samples_result: median
-sample_retract_dist: 2
-samples_tolerance: 0.1
-samples_tolerance_retries: 5
-
-[force_move]
-enable_force_move: True
-
-
-[quad_gantry_level]
-gantry_corners:
-  0,0
-  290,390
-
-points:
-  25,25
-  25,380
-  290,380
-  290,25
-
-speed: 250
-horizontal_move_z: 20
-retries: 3
-retry_tolerance: 0.12
-max_adjust: 50
-
-# Driver1
-[stepper_x]
-step_pin: PF13
-dir_pin: !PF12
-enable_pin: !PF14
-microsteps: 16
-endstop_pin: ^!PE8
-rotation_distance: 3.2
-step_pulse_duration: 0.0000002
-position_endstop: 0
-position_max: 300
-homing_speed: 50
-
-
-[gcode_button kill_switch]
-pin: !PG11
-press_gcode: 
-    PAUSE
-    M118 X or Y motion is blocked.
-    M107
-    M104 S0 
-    M140 S0
-
-
-# Driver0
-[stepper_y]
-step_pin: PG0
-dir_pin: !PG1
-enable_pin: !PF15
-step_pulse_duration: 0.0000002
-microsteps: 16
-endstop_pin: ^!PE9
-rotation_distance: 3.2
-position_endstop: 0
-position_max: 400
-homing_speed: 50
-
-
-[homing_override]
-axes: xyz
-set_position_z: 0
-gcode:
-  LM_ENABLE
-  {% if not 'Z' in params and not 'Y' in params and 'X' in params %}
-    G28 X
-  {% elif not 'Z' in params and not 'X' in params and 'Y' in params %}
-    G28 Y    
-  {% elif not 'Z' in params and 'X' in params and 'Y' in params %}
-    G28 X
-    G28 Y
-  
-  {% else %}
-    G90
-    G1 Z5
-    G28 X
-    G28 Y
-    G0 X150 Y200 F6000
-    G4 P3000
-    LC28
-    G28 Z
-    G1 Z5
-  {% endif %}
-
-[bed_mesh]
-mesh_min: 0, 0
-mesh_max: 270,380
-speed: 150
-horizontal_move_z: 2
-probe_count: 6,8
-algorithm: bicubic
-split_delta_z: 0.0125
-move_check_distance: 3
-mesh_pps: 4,4
-fade_start: 0
-fade_end: 3
-fade_target: 0
-
+# Currently reccomended to not change this.
+# The linear motors have built in smoothing as well
+[input_shaper]
+shaper_type_y = zv
+shaper_freq_y = 27.0
+shaper_type_x = ei
+shaper_freq_x = 44.4
 
 #####################################################################
-# 	Z Stepper Settings
+#   Bed
 #####################################################################
-
-## Z0 Stepper - Front Left on MOTOR2_1
-[stepper_z]
-step_pin: PF11
-dir_pin: !PG3
-enable_pin: !PG5
-endstop_pin: probe:z_virtual_endstop
-rotation_distance: 4
-microsteps: 16
-#endstop_pin: PG10
-##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
-##  (+) value = endstop above Z0, (-) value = endstop below
-##	Increasing position_endstop brings nozzle closer to the bed
-##  After you run Z_ENDSTOP_CALIBRATE, position_endstop will be stored at the very end of your config
-# position_endstop: -1.0
-##--------------------------------------------------------------------
-
-##	Uncomment below for 250mm build
-#position_max: 240
-
-##	Uncomment below for 300mm build
-position_max: 300
-
-##	Uncomment below for 350mm build
-#position_max: 340
-
-##--------------------------------------------------------------------
-position_min: -35
-homing_speed: 5
-second_homing_speed: 2
-homing_retract_dist: 3
-
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmc2209 stepper_z]
-uart_pin: PC6
-interpolate: true
-run_current: 0.9
-hold_current: 0.5
-sense_resistor: 0.110
-stealthchop_threshold: 100
-
-##	Z1 Stepper - Rear Left on MOTOR3
-[stepper_z1]
-step_pin: PG4
-dir_pin: !PC1
-enable_pin: !PA2
-rotation_distance: 4
-microsteps: 16
-
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmc2209 stepper_z1]
-uart_pin: PC7
-interpolate: true
-run_current: 0.9
-hold_current: 0.5
-sense_resistor: 0.110
-stealthchop_threshold: 100
-
-##	Z2 Stepper - Rear Right on MOTOR4
-[stepper_z2]
-step_pin: PF9
-dir_pin: !PF10
-enable_pin: !PG2
-rotation_distance: 4
-#gear_ratio: 80:16
-microsteps: 16
-
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmc2209 stepper_z2]
-uart_pin: PF2
-interpolate: true
-run_current: 0.9
-hold_current: 0.50
-sense_resistor: 0.110
-stealthchop_threshold: 100
-
-##	Z3 Stepper - Front Right on MOTOR5
-[stepper_z3]
-step_pin: PC13
-dir_pin: !PF0
-enable_pin: !PF1
-rotation_distance: 4
-#gear_ratio: 80:16
-microsteps: 16
-
-##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmc2209 stepper_z3]
-uart_pin: PE4
-interpolate: true
-run_current: 0.9
-hold_current: 0.50
-sense_resistor: 0.110
-stealthchop_threshold: 100
 
 [heater_bed]
 heater_pin: PA1
@@ -236,7 +63,164 @@ pid_kd = 1169.116
 min_temp: -200
 max_temp: 130
 
-## Fan Configuration
+#####################################################################
+#	  Probe
+#####################################################################
+
+[probe]
+pin: PE12
+x_offset: 0
+y_offset: 0
+z_offset: -0.11
+speed: 1
+lift_speed: 7
+samples: 3
+samples_result: median
+sample_retract_dist: 2
+samples_tolerance: 0.07
+samples_tolerance_retries: 5
+
+[force_move]
+enable_force_move: True
+
+[quad_gantry_level]
+gantry_corners:
+  -54.8,-35.8
+  412.8,367.8
+
+points:
+  10,10
+  10,290
+  390,290
+  390,10
+
+speed: 250
+horizontal_move_z: 5
+retries: 3
+retry_tolerance: 0.12
+max_adjust: 4
+
+[bed_mesh]
+mesh_min: 0, 0
+mesh_max: 380,280
+speed: 150
+horizontal_move_z: 2
+probe_count: 8,6
+algorithm: bicubic
+split_delta_z: 0.0125
+move_check_distance: 3
+mesh_pps: 4,4
+fade_start: 0
+fade_end: 3
+fade_target: 0
+
+#####################################################################
+#	  Gantry
+#####################################################################
+
+# Driver0
+[stepper_x]
+step_pin: PG0
+dir_pin: !PG1
+enable_pin: !PF15
+step_pulse_duration: 0.0000002
+microsteps: 16
+endstop_pin: ^!PE9
+rotation_distance: 3.2
+position_endstop: 0
+position_max: 400
+homing_speed: 50
+
+# Driver1
+[stepper_y]
+step_pin: PF13
+dir_pin: PF12
+enable_pin: !PF14
+microsteps: 16
+endstop_pin: ^!PE8
+rotation_distance: 3.2
+step_pulse_duration: 0.0000002
+position_endstop: 300
+position_max: 300
+homing_speed: 50
+
+#####################################################################
+# 	Z Stepper Settings
+#####################################################################
+
+## Z0 Stepper - Front Left on MOTOR5
+[stepper_z]
+step_pin: PC13
+dir_pin: !PF0
+enable_pin: !PF1
+endstop_pin: probe:z_virtual_endstop
+rotation_distance: 4
+microsteps: 16
+position_max: 300
+position_min: -20
+homing_speed: 5
+second_homing_speed: 1
+homing_retract_dist: 3
+
+[tmc2209 stepper_z]
+uart_pin: PE4
+interpolate: true
+run_current: 0.7
+hold_current: 0.50
+sense_resistor: 0.110
+stealthchop_threshold: 100
+
+##	Z1 Stepper - Rear Left on MOTOR2_1
+[stepper_z1]
+step_pin: PF11
+dir_pin: !PG3
+enable_pin: !PG5
+rotation_distance: 4
+microsteps: 16
+
+[tmc2209 stepper_z1]
+uart_pin: PC6
+interpolate: true
+run_current: 0.7
+hold_current: 0.5
+sense_resistor: 0.110
+stealthchop_threshold: 100
+
+##	Z2 Stepper - Rear Right on MOTOR3
+[stepper_z2]
+step_pin: PG4
+dir_pin: !PC1
+enable_pin: !PA2
+rotation_distance: 4
+microsteps: 16
+
+[tmc2209 stepper_z2]
+uart_pin: PC7
+interpolate: true
+run_current: 0.7
+hold_current: 0.5
+sense_resistor: 0.110
+stealthchop_threshold: 100
+
+##	Z3 Stepper - Front Right on MOTOR4
+[stepper_z3]
+step_pin: PF9
+dir_pin: !PF10
+enable_pin: !PG2
+rotation_distance: 4
+microsteps: 16
+
+[tmc2209 stepper_z3]
+uart_pin: PF2
+interpolate: true
+run_current: 0.7
+hold_current: 0.50
+sense_resistor: 0.110
+stealthchop_threshold: 100
+
+#####################################################################
+# 	Fans
+#####################################################################
 
 [multi_pin part_cooling]
 pins: MAG_TOOL:gpio17, MAG_TOOL:gpio11
@@ -245,7 +229,6 @@ pins: MAG_TOOL:gpio17, MAG_TOOL:gpio11
 pins: MAG_TOOL:gpio3, MAG_TOOL:gpio2
 
 [temperature_fan pi]
-# Electronics fan PWM
 pin: PD15
 max_power: 0.60
 control: watermark
@@ -271,84 +254,46 @@ kick_start_time: 0.5
 cycle_time: 0.01
 off_below: 0.4
 
-# CAN bus is also available on this board
+#####################################################################
+# 	Lighting
+#####################################################################
 
-[exclude_object]
-
-[respond]
-
-[printer]
-kinematics: cartesian
-max_velocity: 1500
-max_accel: 15000
-max_z_velocity: 5
-max_z_accel: 100
-
-[board_pins]
-aliases:
-    # EXP1 header
-    EXP1_1=PE8, EXP1_2=PE7,
-    EXP1_3=PE9, EXP1_4=PE10,
-    EXP1_5=PE12, EXP1_6=PE13,    # Slot in the socket on this side
-    EXP1_7=PE14, EXP1_8=PE15,
-    EXP1_9=<GND>, EXP1_10=<5V>,
-
-    # EXP2 header
-    EXP2_1=PA6, EXP2_2=PA5,
-    EXP2_3=PB1, EXP2_4=PA4,
-    EXP2_5=PB2, EXP2_6=PA7,      # Slot in the socket on this side
-    EXP2_7=PC15, EXP2_8=<RST>,
-    EXP2_9=<GND>, EXP2_10=PC5
-
- 
-[output_pin _led_pin]
-pin:PE13
-pwm:False
-value:0
+[led Chamber_Lights]
+white_pin:PD14
 
 [gcode_macro TOGGLE_LIGHTS]
 gcode:
-  {% if printer['output_pin _led_pin'].value == 1 %}
-    SET_PIN PIN=_led_pin VALUE=0
+  {% if printer['led Chamber_Lights'].color_data[0][3] > 0 %}
+    SET_LED LED=Chamber_Lights WHITE=0.0
   {% else %}
-    SET_PIN PIN=_led_pin VALUE=1
+    SET_LED LED=Chamber_Lights WHITE=0.5
   {% endif %}
 
-[input_shaper]
-shaper_type_y = zv
-shaper_freq_y = 27.0
-shaper_type_x = ei
-shaper_freq_x = 44.4
+#####################################################################
+# 	Critical Macros/Overrides
+#####################################################################
 
+[gcode_button kill_switch]
+pin: !PG11
+press_gcode: 
+    PAUSE
+    M118 X or Y motion is blocked.
+    M107
+    M104 S0 
+    M140 S0
 
-# [output_pin beeper_pin]
-# pin: EXP1_1
-# pwm: true
-# value: 0
-# # shutdown_value: 0
-# cycle_time: 0.001
-
-#*# <---------------------- SAVE_CONFIG ---------------------->
-#*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.
-#*#
-#*# [bed_mesh default]
-#*# version = 1
-#*# points =
-#*# 	  -0.183750, -0.067500, -0.010000, 0.026250, -0.036250, -0.111250
-#*# 	  -0.193750, -0.060000, 0.008750, 0.036250, 0.002500, -0.117500
-#*# 	  -0.236250, -0.066250, 0.025000, 0.050000, 0.000000, -0.073750
-#*# 	  -0.238750, -0.091250, 0.003750, 0.025000, -0.028750, -0.117500
-#*# 	  -0.268750, -0.121250, 0.020000, 0.043750, -0.002500, -0.115000
-#*# 	  -0.292500, -0.115000, 0.021250, 0.065000, 0.002500, -0.145000
-#*# 	  -0.287500, -0.091250, 0.057500, 0.105000, 0.037500, -0.073750
-#*# 	  -0.256250, -0.033750, 0.126250, 0.186250, 0.111250, -0.043750
-#*# x_count = 6
-#*# y_count = 8
-#*# mesh_x_pps = 4
-#*# mesh_y_pps = 4
-#*# algo = bicubic
-#*# tension = 0.2
-#*# min_x = 0.0
-#*# max_x = 270.0
-#*# min_y = 0.0
-#*# max_y = 379.96
+[homing_override]
+axes: z
+set_position_z: 0
+gcode:
+  _LM_ENABLE
+  G90
+  G1 Z5
+  {% if "xy" not in printer.toolhead.homed_axes %}
+    G28 X
+    G28 Y
+  {% endif %}
+  G0 X200 Y150 F6000
+  LC28
+  G28 Z
+  G1 Z5

--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -40,6 +40,9 @@ timeout: 3600
 [gcode_arcs]
 resolution:0.1
 
+[force_move]
+enable_force_move: True
+
 # Currently reccomended to not change this.
 # The linear motors have built in smoothing as well
 [input_shaper]
@@ -79,9 +82,6 @@ samples_result: median
 sample_retract_dist: 2
 samples_tolerance: 0.07
 samples_tolerance_retries: 5
-
-[force_move]
-enable_force_move: True
 
 [quad_gantry_level]
 gantry_corners:


### PR DESCRIPTION
### **BREAKING CHANGES: These changes rotate the printer so the "Front" is in the logical location!**
**The slicer MUST be updated to have X be 400, Y 300, and start G code needs to be set to just the following:**
`M190 S[bed_temperature_initial_layer_single]
M109 S[nozzle_temperature_initial_layer]
PRINT_START`

(I do not have a PR open to do the above required Printer Profile changes in the slicer; the Peopoly team would need to do that themselves for the OrcaSlicer repo.)

Redefines/updates macros, organizes configs, updates the QGL locations to be more accurate, and a general spelling check pass.

Removes forced temperatures on QGL and bed meshing so people can set them as they need, as both temps very based on filament. 